### PR TITLE
Set default stack size + static data size to 576KB

### DIFF
--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -26,7 +26,7 @@ fi
 $JSSHELL "$approot/scripts/fix-sfile.js" "$sfile~" > "$sfile"
 rm "$sfile~"
 
-$BYNARYEN_ROOT/s2wasm "$sfile" -i 589824 -s 524288 > "$wastfile"
+$BYNARYEN_ROOT/s2wasm "$sfile" -i 655360 > "$wastfile"
 if [ $? != 0 ];then
   exit 3
 fi

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -26,7 +26,7 @@ fi
 $JSSHELL "$approot/scripts/fix-sfile.js" "$sfile~" > "$sfile"
 rm "$sfile~"
 
-$BYNARYEN_ROOT/s2wasm "$sfile" -i 655360 > "$wastfile"
+$BYNARYEN_ROOT/s2wasm "$sfile" -s 524288  > "$wastfile"
 if [ $? != 0 ];then
   exit 3
 fi

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -26,7 +26,7 @@ fi
 $JSSHELL "$approot/scripts/fix-sfile.js" "$sfile~" > "$sfile"
 rm "$sfile~"
 
-$BYNARYEN_ROOT/s2wasm "$sfile" > "$wastfile"
+$BYNARYEN_ROOT/s2wasm "$sfile" -i 589824 -s 524288 > "$wastfile"
 if [ $? != 0 ];then
   exit 3
 fi


### PR DESCRIPTION
(correction to #4 setting valid values)

When using WASM Explorer or WASM Fiddle, any use of the stack will cause a memory out of bounds exception.

By passing the -s option to s2wasm we can initialize the stack value to the top of the initial memory.

This PR sets the total stack + static data size to 576KB (which seems like a sensible default). Ideally these should be parameters into the service though to tune requirements. Also it should be possible to inspect the static data size of a compilation and ensure that the stack size is always a constant stack size value regardless of the static data size, which would be an even more sensible default.

This at now will at least allow experimentation with stack things, as this service is hopefully intended for.